### PR TITLE
Send HTTP errors as raw strings instead of HTML documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGELOG
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Send HTTP errors as raw strings instead of HTML documents
 
 
 1.1.0 (2014-05-21)


### PR DESCRIPTION
This will help clients to track errors. Currently mapentity logs the firsts 150 chars so we lose the interesting part ot the message.
