### PR TITLE
always use python3-gunicorn

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Architecture: any
 Depends:
  ${misc:Depends},
  ${python3:Depends},
- gunicorn3 | gunicorn,
+ python3-gunicorn,
  unoconv,
  inkscape
 Description: A file conversion Web API in Pyramid


### PR DESCRIPTION
gunicorn3 is not available on ubuntu focal
python3-gunicorn is available on both ubuntu bionic and focal
gunicorn fallback install cause troubles with screamshotter gunicorn dependency